### PR TITLE
画像ID/画像名の対応付け ＆ 学習用/評価用のデータセット分割

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .ipynb_checkpoints/
-af_dataset.record
+af_dataset*.record
 data-manabiya.tar.gz
 data-manabiya/
 frozen/

--- a/Step1_DataConvert.ipynb
+++ b/Step1_DataConvert.ipynb
@@ -86,6 +86,15 @@
    },
    "outputs": [],
    "source": [
+    "data_path = \"./data-manabiya/width1000/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def printRecursive(obj, depth=0):\n",
     "    if isinstance(obj, dict):\n",
     "        for k, v in obj.items():\n",
@@ -97,7 +106,7 @@
     "            printRecursive(v, depth + 1)\n",
     "            \n",
     "            \n",
-    "for annotation_json_path in glob.glob(\"./data-manabiya/width1000/json/*.json\"):\n",
+    "for annotation_json_path in glob.glob(data_path + \"json/*.json\"):\n",
     "    print(annotation_json_path)\n",
     "    json_dict = json.load(open(annotation_json_path, 'r'))\n",
     "    printRecursive(json_dict)"
@@ -156,9 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "re_example_type = re.compile(\"^(\\S+)\\s\")\n",
@@ -206,9 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"指定した点を全て含む矩形（＝Bounding Box）を返す。\"\"\"\n",
@@ -227,20 +232,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"input_data_id と ファイル名の対応辞書\"\"\"\n",
+    "\"\"\"\n",
+    "input_data_id と ファイル名の対応辞書を作成します。今回は、全体の画像のうち、\n",
+    "* 80% 学習用（train）\n",
+    "* 20% 評価用（eval）\n",
+    "に分けます。恣意性が入らないようにランダムに分けます\"\"\"\n",
+    "\n",
+    "import random \n",
+    "random.seed(20180323)\n",
+    "\n",
+    "inputs_json_path = data_path + \"inputs.json\"         \n",
+    "inputs_json_dict = json.load(open(inputs_json_path, 'r'))\n",
+    "input_data_list = inputs_json_dict[\"list\"]\n",
+    "random.shuffle(input_data_list)\n",
+    "\n",
+    "needle_80 = int(len(input_data_list) * 0.8)\n",
+    "(for_train, for_eval) = input_data_list[0:needle_80], input_data_list[needle_80:]\n",
+    "\n",
+    "def to_id_name_mapping(input_data_list):\n",
+    "    return {str(e[\"input_data_id\"]): str(e[\"input_data_name\"])  for e in input_data_list}\n",
+    "\n",
     "input_data_id_2_input_name = {\n",
-    "    \"2e152501-d5d9-4026-bde0-7c28c1e773e0\":\"540782936.273833.png\",\n",
-    "    \"41816be2-3f57-4be9-bfd3-d228a4c1ca69\":\"540782823.324211.png\",\n",
-    "    \"418fc9c8-3ec4-49b2-8176-a8cf5376c026\":\"540782586.412328.png\",\n",
-    "    \"85228d61-209f-4675-b30b-fd842b5623a1\":\"540782457.810163.png\",\n",
-    "    \"b257a1e9-433d-480d-a41e-ef1dbf29d67e\":\"540782780.456003.png\",\n",
-    "    \"b4c190e3-9599-4d7f-9d97-d23b09752fdc\":\"540782910.323475.png\"\n",
-    "}"
+    "    \"train\": to_id_name_mapping(for_train),\n",
+    "    \"eval\": to_id_name_mapping(for_eval),\n",
+    "}\n",
+    "input_data_id_2_input_name"
    ]
   },
   {
@@ -291,69 +310,62 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "# TFRecords 形式のファイル名\n",
-    "tfrecords_out_path = \"af_dataset.record\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
-    "# 変換実施\n",
-    "with tf.python_io.TFRecordWriter(tfrecords_out_path) as writer:\n",
-    "    for annotation_json_path in glob.glob(\"./data-manabiya/width1000/json/*.json\"):\n",
-    "        json_dict = json.load(open(annotation_json_path, 'r'))\n",
-    "        filename = input_data_id_2_input_name[json_dict[\"input_data_id\"]]\n",
-    "        image_path = \"./data-manabiya/width1000/image/{}\".format(filename)\n",
-    "        # 画像サイズは決め打ち\n",
-    "        width,height = 1000.0, 750.0\n",
-    "        encoded_image_data = byte_encode_image(image_path)\n",
-    "        \n",
-    "        # 1画像内の複数アノテーションを扱うため配列\n",
-    "        xmins = []\n",
-    "        xmaxs = []\n",
-    "        ymins = []\n",
-    "        ymaxs = []\n",
-    "        classes_text = []\n",
-    "        classes = []\n",
-    "        \n",
-    "        for annotation in json_dict[\"detail\"]:           \n",
-    "            flat_coordinates = annotation[\"data\"].split(\",\")\n",
-    "            xy_coordinates = [(int(x),int(y)) for (x,y) in zip(*[iter(flat_coordinates)]*2)]\n",
-    "            min_x, min_y, max_x, max_y = bounding_box(xy_coordinates)\n",
-    "            xmins.append(min_x / width)\n",
-    "            ymins.append(min_y / height)\n",
-    "            xmaxs.append(max_x / width)\n",
-    "            ymaxs.append(max_y / height)\n",
-    "            class_text = str(annotation[\"additional_data_list\"][0][\"choice\"])\n",
-    "            classes_text.append(class_text)\n",
-    "            classes.append(class_text_2_index[class_text])\n",
     "\n",
-    "        example = tf.train.Example(features=tf.train.Features(feature={\n",
-    "            'image/height': dataset_util.int64_feature(int(height)),\n",
-    "            'image/width': dataset_util.int64_feature(int(width)),\n",
-    "            'image/filename': dataset_util.bytes_feature(filename),\n",
-    "            'image/source_id': dataset_util.bytes_feature(filename),\n",
-    "            'image/encoded': dataset_util.bytes_feature(encoded_image_data),\n",
-    "            'image/format': dataset_util.bytes_feature(\"png\"),\n",
-    "            'image/object/bbox/xmin': dataset_util.float_list_feature(xmins),\n",
-    "            'image/object/bbox/xmax': dataset_util.float_list_feature(xmaxs),\n",
-    "            'image/object/bbox/ymin': dataset_util.float_list_feature(ymins),\n",
-    "            'image/object/bbox/ymax': dataset_util.float_list_feature(ymaxs),\n",
-    "            'image/object/class/text': dataset_util.bytes_list_feature(classes_text),\n",
-    "            'image/object/class/label': dataset_util.int64_list_feature(classes),\n",
-    "        }))\n",
-    "        writer.write(example.SerializeToString())"
+    "def generate_tfrecord(out_path, id_2_name_mapping):\n",
+    "    with tf.python_io.TFRecordWriter(out_path) as writer:\n",
+    "        for annotation_json_path in glob.glob(data_path + \"json/*.json\"):\n",
+    "            json_dict = json.load(open(annotation_json_path, 'r'))\n",
+    "            filename = id_2_name_mapping.get(json_dict[\"input_data_id\"], None)\n",
+    "            if (filename is None):\n",
+    "                continue\n",
+    "            \n",
+    "            image_path = data_path + \"image/{}\".format(filename)\n",
+    "            # 画像サイズは決め打ち\n",
+    "            width,height = 1000.0, 750.0\n",
+    "            encoded_image_data = byte_encode_image(image_path)\n",
+    "\n",
+    "            # 1画像内の複数アノテーションを扱うため配列\n",
+    "            xmins = []\n",
+    "            xmaxs = []\n",
+    "            ymins = []\n",
+    "            ymaxs = []\n",
+    "            classes_text = []\n",
+    "            classes = []\n",
+    "\n",
+    "            for annotation in json_dict[\"detail\"]:           \n",
+    "                xy_coordinates = [(int(e[\"x\"]),int(e[\"y\"])) for e in annotation[\"data\"]]\n",
+    "                min_x, min_y, max_x, max_y = bounding_box(xy_coordinates)\n",
+    "                xmins.append(min_x / width)\n",
+    "                ymins.append(min_y / height)\n",
+    "                xmaxs.append(max_x / width)\n",
+    "                ymaxs.append(max_y / height)\n",
+    "                class_text = str(annotation[\"additional_data_list\"][0][\"choice\"])\n",
+    "                classes_text.append(class_text)\n",
+    "                classes.append(class_text_2_index[class_text])\n",
+    "\n",
+    "            example = tf.train.Example(features=tf.train.Features(feature={\n",
+    "                'image/height': dataset_util.int64_feature(int(height)),\n",
+    "                'image/width': dataset_util.int64_feature(int(width)),\n",
+    "                'image/filename': dataset_util.bytes_feature(filename),\n",
+    "                'image/source_id': dataset_util.bytes_feature(filename),\n",
+    "                'image/encoded': dataset_util.bytes_feature(encoded_image_data),\n",
+    "                'image/format': dataset_util.bytes_feature(\"png\"),\n",
+    "                'image/object/bbox/xmin': dataset_util.float_list_feature(xmins),\n",
+    "                'image/object/bbox/xmax': dataset_util.float_list_feature(xmaxs),\n",
+    "                'image/object/bbox/ymin': dataset_util.float_list_feature(ymins),\n",
+    "                'image/object/bbox/ymax': dataset_util.float_list_feature(ymaxs),\n",
+    "                'image/object/class/text': dataset_util.bytes_list_feature(classes_text),\n",
+    "                'image/object/class/label': dataset_util.int64_list_feature(classes),\n",
+    "            }))\n",
+    "            writer.write(example.SerializeToString())\n",
+    "            \n",
+    "# 変換実施\n",
+    "generate_tfrecord(\"af_dataset_train.record\", input_data_id_2_input_name[\"train\"])\n",
+    "generate_tfrecord(\"af_dataset_eval.record\", input_data_id_2_input_name[\"eval\"])"
    ]
   },
   {
@@ -375,7 +387,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -400,9 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",

--- a/ssd_mobilenet_v1_manabiya.pbtxt
+++ b/ssd_mobilenet_v1_manabiya.pbtxt
@@ -174,7 +174,7 @@ train_config: {
 
 train_input_reader: {
   tf_record_input_reader {
-    input_path: "./af_dataset.record"
+    input_path: "./af_dataset_train.record"
   }
   label_map_path: "./label_map.pbtxt"
 }
@@ -188,7 +188,7 @@ eval_config: {
 
 eval_input_reader: {
   tf_record_input_reader {
-    input_path: "./af_dataset.record"
+    input_path: "./af_dataset_eval.record"
   }
   label_map_path: "./label_map.pbtxt"
   shuffle: false


### PR DESCRIPTION
Closes #7  & #13

* idとnameのリレーションはinputs.jsonから生成できるようにする
* trainとeval用のデータセットを分割する
